### PR TITLE
RMET-1195 File Transfer Plugin - Update dependency to File Plugin

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -19,6 +19,9 @@
 #
 -->
 # Release Notes
+
+### Unreleased
+* Updates dependency for cordova-file-plugin so that version 6.0.2-OS4 is used.
                                               
 ### 1.7.1 (Jan 24, 2018)
 * [CB-13749](https://issues.apache.org/jira/browse/CB-13749) Add build-tools-26.0.2 to travis

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,7 @@
     <repo>https://github.com/apache/cordova-plugin-file-transfer</repo>
     <issue>https://github.com/apache/cordova-plugin-file-transfer/issues</issue>
 
-    <dependency id="cordova-plugin-file" version=">=6.0.2-OS" />
+    <dependency id="cordova-plugin-file" url="https://github.com/OutSystems/cordova-plugin-file.git#fix/RMET-1195/add-request-legacy-storage" />
 
     <js-module src="www/FileTransferError.js" name="FileTransferError">
         <clobbers target="window.FileTransferError" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,7 @@
     <repo>https://github.com/apache/cordova-plugin-file-transfer</repo>
     <issue>https://github.com/apache/cordova-plugin-file-transfer/issues</issue>
 
-    <dependency id="cordova-plugin-file" url="https://github.com/OutSystems/cordova-plugin-file.git#fix/RMET-1195/add-request-legacy-storage" />
+    <dependency id="cordova-plugin-file" url="https://github.com/OutSystems/cordova-plugin-file.git#6.0.2-OS4" />
 
     <js-module src="www/FileTransferError.js" name="FileTransferError">
         <clobbers target="window.FileTransferError" />


### PR DESCRIPTION
## Description
Updates dependency to file plugin so that version 6.0.2-OS4 is used. This version contains a hook to add the `android:requestLegacyExternalStorage=true` for Android 10.


## Context
Fixes: https://outsystemsrd.atlassian.net/browse/RMET-1195.


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [ ] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [x] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)


## Platforms affected
- [x] Android
- [ ] iOS

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested changes locally and also tested MABS 7 and 8 builds.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly