### PR TITLE
RMET-4065 :: Update cordova file plugin dependency

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,7 +20,7 @@
 -->
 # Release Notes
 
-### [Unreleased] (Feb 7, 2024)
+### 2.1.0-OS3 (Feb 7, 2024)
 * Updates dependency for cordova-file-plugin so that version 6.0.2-OS9 is used.
 
 ### 2.1.0-OS2 (Nov 16, 2021)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,9 @@
 -->
 # Release Notes
 
+### [Unreleased] (Feb 7, 2024)
+* Updates dependency for cordova-file-plugin so that version 6.0.2-OS9 is used.
+
 ### 2.1.0-OS2 (Nov 16, 2021)
 * Updates dependency for cordova-file-plugin so that version 6.0.2-OS4 is used.
                                               

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-file-transfer",
-  "version": "2.1.0-OS2",
+  "version": "2.1.0-OS3",
   "description": "Cordova File Transfer Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,7 @@
     <repo>https://github.com/apache/cordova-plugin-file-transfer</repo>
     <issue>https://github.com/apache/cordova-plugin-file-transfer/issues</issue>
 
-    <dependency id="cordova-plugin-file" url="https://github.com/OutSystems/cordova-plugin-file.git#6.0.2-OS4" />
+    <dependency id="cordova-plugin-file" url="https://github.com/OutSystems/cordova-plugin-file.git#6.0.2-OS9" />
 
     <js-module src="www/FileTransferError.js" name="FileTransferError">
         <clobbers target="window.FileTransferError" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-file-transfer"
-    version="2.1.0-OS2">
+    version="2.1.0-OS3">
     <name>File Transfer</name>
     <description>Cordova File Transfer Plugin</description>
     <license>Apache 2.0</license>


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

AFAIK was only causing an issue on Android, but could be affecting other platforms.


### Motivation and Context


https://outsystemsrd.atlassian.net/browse/RMET-4065


### Description

The plugin's dependency of [cordova-file-plugin](https://github.com/OutSystems/cordova-plugin-file/releases) is outdated, and was causing issues, mainly related to `FileReader` override of 6.0.2-OS6.

This PR updates the version to the latest.



### Testing

Used an Outsystems sample app called [JPT_FileUpload on ODC](https://eng-mobile.outsystems.dev/apps/application?id=a7790d6c-fd84-4486-b5bb-bb9b60242b34), where reading of files was causing issues on Android with the UploadWidget.

- Before (issue): https://github.com/user-attachments/assets/9314aa05-5464-4ced-b257-ec8e1a712623


- After (this PR): https://github.com/user-attachments/assets/b7d5a676-f003-461e-9f0e-1b3289e93705




### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
